### PR TITLE
Set Payload size limits at networking layer

### DIFF
--- a/shardus_net/src/lib.rs
+++ b/shardus_net/src/lib.rs
@@ -38,7 +38,8 @@ use tokio::sync::Mutex;
 use crate::shardus_net_sender::Connection;
 
 const ENABLE_COMPRESSION: bool = false;
-const HEADER_SIZE_LIMIT_IN_BYTES: usize = 2 * 2048; // 2KB
+const HEADER_SIZE_LIMIT_IN_BYTES: usize = 2 * 1024; // 2KB
+const PAYLOAD_SIZE_LIMIT_IN_BYTES: usize = 2 * 1024 * 1024; // 2MB
 
 fn create_shardus_net(mut cx: FunctionContext) -> JsResult<JsObject> {
     let cx = &mut cx;

--- a/shardus_net/src/lib.rs
+++ b/shardus_net/src/lib.rs
@@ -569,8 +569,10 @@ fn get_sender_address(mut cx: FunctionContext) -> JsResult<JsObject> {
     let gas_valid = gas_limit.ge(&base_fee);
 
     let js_is_valid = cx.boolean(is_valid & gas_valid);
+    let js_gas_valid = cx.boolean(gas_valid);
     result.set(cx, "address", js_addr)?;
     result.set(cx, "isValid", js_is_valid)?;
+    result.set(cx, "gasValid", js_gas_valid)?;
 
     Ok(result)
 }

--- a/shardus_net/src/shardus_net_listener.rs
+++ b/shardus_net/src/shardus_net_listener.rs
@@ -1,7 +1,7 @@
 use crate::header::header_types::RequestMetadata;
 use crate::header_factory::header_deserialize_factory;
 use crate::message::Message;
-use crate::{shardus_crypto, HEADER_SIZE_LIMIT_IN_BYTES};
+use crate::{shardus_crypto, HEADER_SIZE_LIMIT_IN_BYTES, PAYLOAD_SIZE_LIMIT_IN_BYTES};
 
 use super::runtime::RUNTIME;
 
@@ -92,6 +92,11 @@ impl ShardusNetListener {
     async fn receive(socket_stream: TcpStream, remote_addr: SocketAddr, received_msg_tx: UnboundedSender<(String, SocketAddr, Option<RequestMetadata>)>) -> ListenerResult<()> {
         let mut socket_stream: TcpStream = socket_stream;
         while let Ok(msg_len) = socket_stream.read_u32().await {
+            if (msg_len as usize) > PAYLOAD_SIZE_LIMIT_IN_BYTES {
+                error!("Message length exceeds the limit of 2MB");
+                continue;
+            }
+
             let mut buffer: Vec<u8> = vec![0; msg_len as usize];
 
             // @TODO: Do a security check in the case that a sender sends an incorrect length.

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,4 +114,4 @@ export interface Sign {
   sig: string
 }
 
-export type GetSenderAddressResult = { address: string; isValid: boolean }
+export type GetSenderAddressResult = { address: string; isValid: boolean; gasValid: boolean }


### PR DESCRIPTION
Currently set to 2MB.

- [ ] Figure out the issue of multiple messages being received if the size of the message is above bounds.